### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lru-diskcache": "1.1.1",
     "octocat": "0.10.2",
     "q": "1.2.0",
-    "request": "2.60.0",
+    "request": "2.74.0",
     "semver": "5.0.1",
     "stream-res": "1.0.1",
     "strip-bom": "2.0.0",


### PR DESCRIPTION
nuts currently has a 5 vulnerable dependency paths, introducing 2 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/GitbookIO/nuts) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `octocat`,`analytics-node` and `body-parser` dependencies as well.

Stay Secure,
The Snyk Team
